### PR TITLE
Minimally fix compilation on Mac with Node.js 0.10.36 and NAN 1.6.1

### DIFF
--- a/src/commandqueue.cpp
+++ b/src/commandqueue.cpp
@@ -104,12 +104,12 @@ NAN_METHOD(GetCommandQueueInfo) {
     case CL_QUEUE_REFERENCE_COUNT: {
       cl_uint val;
       CHECK_ERR(::clGetCommandQueueInfo(q,param_name,sizeof(cl_uint), &val, nullptr))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
     case CL_QUEUE_PROPERTIES: {
       cl_command_queue_properties val;
       CHECK_ERR(::clGetCommandQueueInfo(q,param_name,sizeof(cl_command_queue_properties), &val, nullptr))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
   }
   return NanThrowError(JS_INT(CL_INVALID_VALUE));

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -129,7 +129,7 @@ NAN_METHOD(GetDeviceInfo) {
 
     Local<Array> arr = Array::New(max_work_item_dimensions);
     for(cl_uint i=0;i<max_work_item_dimensions;i++)
-      arr->Set(i,JS_INT(param_value[i]));
+      arr->Set(i,JS_INT(uint32_t(param_value[i])));
 
     NanReturnValue(arr);
   }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -184,7 +184,7 @@ NAN_METHOD(GetKernelArgInfo) {
     case CL_KERNEL_ARG_TYPE_QUALIFIER: {
       cl_kernel_arg_type_qualifier num=0;
       CHECK_ERR(::clGetKernelInfo(k,param_name,sizeof(cl_kernel_arg_type_qualifier),&num, NULL));
-      NanReturnValue(JS_INT(num));
+      NanReturnValue(JS_INT(uint32_t(num)));
     }
     case CL_KERNEL_ARG_TYPE_NAME:
     case CL_KERNEL_ARG_NAME: {
@@ -226,22 +226,22 @@ NAN_METHOD(GetKernelWorkGroupInfo) {
       size_t sz[3]{0,0,0};
       CHECK_ERR(::clGetKernelWorkGroupInfo(k,d,param_name,3*sizeof(size_t),sz, NULL));
       Local<Array> szarr = Array::New();
-      szarr->Set(0,JS_INT(sz[0]));
-      szarr->Set(1,JS_INT(sz[1]));
-      szarr->Set(2,JS_INT(sz[2]));
+      szarr->Set(0,JS_INT(uint32_t(sz[0])));
+      szarr->Set(1,JS_INT(uint32_t(sz[1])));
+      szarr->Set(2,JS_INT(uint32_t(sz[2])));
       NanReturnValue(szarr);
     }
     case CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE:
     case CL_KERNEL_WORK_GROUP_SIZE: {
       size_t sz=0;
       CHECK_ERR(::clGetKernelWorkGroupInfo(k,d,param_name,sizeof(size_t),&sz, NULL));
-      NanReturnValue(JS_INT(sz));
+      NanReturnValue(JS_INT(uint32_t(sz)));
     }
     case CL_KERNEL_LOCAL_MEM_SIZE:
     case CL_KERNEL_PRIVATE_MEM_SIZE: {
       cl_ulong sz=0;
       CHECK_ERR(::clGetKernelWorkGroupInfo(k,d,param_name,sizeof(cl_ulong),&sz, NULL));
-      NanReturnValue(JS_INT(sz));
+      NanReturnValue(JS_INT(uint32_t(sz)));
     }
   }
 

--- a/src/memobj.cpp
+++ b/src/memobj.cpp
@@ -247,14 +247,14 @@ NAN_METHOD(GetMemObjectInfo) {
     case CL_MEM_FLAGS: {
       cl_mem_flags val;
       CHECK_ERR(::clGetMemObjectInfo(mem,param_name,sizeof(cl_mem_flags), &val, NULL))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
     case CL_MEM_SIZE:
     case CL_MEM_OFFSET:
     {
       size_t val;
       CHECK_ERR(::clGetMemObjectInfo(mem,param_name,sizeof(size_t), &val, NULL))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
     case CL_MEM_MAP_COUNT:
     case CL_MEM_REFERENCE_COUNT:
@@ -317,7 +317,7 @@ NAN_METHOD(GetImageInfo) {
     {
       size_t val;
       CHECK_ERR(::clGetImageInfo(mem,param_name,sizeof(size_t), &val, NULL))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
     case CL_IMAGE_BUFFER: {
       cl_mem val;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -238,7 +238,7 @@ NAN_METHOD(GetProgramInfo) {
       CHECK_ERR(::clGetProgramInfo(prog, param_name, nsizes*sizeof(size_t), sizes.get(), NULL));
       Local<Array> arr = Array::New(nsizes);
       for(cl_uint i=0;i<nsizes;i++)
-        arr->Set(i,JS_INT(sizes[i]));
+        arr->Set(i,JS_INT(uint32_t(sizes[i])));
 
       NanReturnValue(arr);
     }
@@ -263,7 +263,7 @@ NAN_METHOD(GetProgramInfo) {
     {
       size_t val;
       CHECK_ERR(::clGetProgramInfo(prog,param_name,sizeof(size_t), &val, NULL))
-      NanReturnValue(JS_INT(val));
+      NanReturnValue(JS_INT(uint32_t(val)));
     }
     case CL_PROGRAM_SOURCE:
     case CL_PROGRAM_KERNEL_NAMES:


### PR DESCRIPTION
Explicitly resolve ambiguity between `New(uint32_t)` and `New(int32_t)`