### PR TITLE
fixing setKernelArg for OpenCL versions < 1.2

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -81,7 +81,7 @@ namespace {
 namespace opencl {
 
 #define ARG_EXISTS(nth) \
-  args.Length() >= nth + 1 && !args[nth]->IsNull() && !args[nth]->IsUndefined()
+  (args.Length() >= nth + 1 && !args[nth]->IsNull() && !args[nth]->IsUndefined())
 
 
 void getPtrAndLen(const Local<Value> value, void* &ptr, int &len);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -211,7 +211,6 @@ public:
   // for deleting the pointer after use.
   std::tuple<size_t, void*, cl_int> convert(const std::string& name, const Local<Value>& val) {
       assert(this->hasType(name));
-      std::cout << "running convertter for type " << name << std::endl;
       // call conversion function and return size of argument and pointer
       return std::move(m_converters[name](val));
   }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -211,6 +211,7 @@ public:
   // for deleting the pointer after use.
   std::tuple<size_t, void*, cl_int> convert(const std::string& name, const Local<Value>& val) {
       assert(this->hasType(name));
+      std::cout << "running convertter for type " << name << std::endl;
       // call conversion function and return size of argument and pointer
       return std::move(m_converters[name](val));
   }
@@ -223,14 +224,20 @@ public:
 //                size_t       /* arg_size */,
 //                const void * /* arg_value */) CL_API_SUFFIX__VERSION_1_0;
 NAN_METHOD(SetKernelArg) {
-  // static member of the function gets initialzed by the first thread
-  // which calls this function. This is thread-safe due to the C++11 standard.
+  // static member of the function gets initialized by the first thread
+  // which calls this function. This is thread-safe according to the C++11 standard.
   // All other threads arriving wait till the constructor initialization is
   // complete before executing the code below.
   static PrimitiveTypeMapCache type_converter;
 
   NanScope();
+#ifdef CL_VERSION_1_2
   REQ_ARGS(3);
+#else
+  // if kernel introspection is not supported, require the type to be
+  // passed as the 4th paramter, otherwise this parameter is optional
+  REQ_ARGS(4);
+#endif
 
   // Arg 0
   NOCL_UNWRAP(k, NoCLKernel, args[0]);
@@ -242,54 +249,66 @@ NAN_METHOD(SetKernelArg) {
   // using OpenCL, and then try to convert arg[2] to the type the kernel
   // expects
 
+  // check if we have kernel introspection available
+  std::string type_name;
+  bool local_arg = false;
+#ifdef CL_VERSION_1_2
   // get address qualifier of kernel (local, global, constant, private), one of:
   // - CL_KERNEL_ARG_ADDRESS_GLOBAL
   // - CL_KERNEL_ARG_ADDRESS_LOCAL
   // - CL_KERNEL_ARG_ADDRESS_CONSTANT
   // - CL_KERNEL_ARG_ADDRESS_PRIVATE
-  cl_kernel_arg_address_qualifier adrqual;
-  CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_ADDRESS_QUALIFIER, sizeof(cl_kernel_arg_address_qualifier), &adrqual, NULL));
+  if(!ARG_EXISTS(3)) {
+    cl_kernel_arg_address_qualifier adrqual;
+    CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_ADDRESS_QUALIFIER, sizeof(cl_kernel_arg_address_qualifier), &adrqual, NULL));
 
-  // get typename (for conversion of the JS parameter)
-  size_t nchars=0;
-  CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_TYPE_NAME, 0, NULL, &nchars));
-  unique_ptr<char[]> type_name(new char[nchars]);
-  CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_TYPE_NAME, nchars, type_name.get(), NULL));
+    // get typename (for conversion of the JS parameter)
+    size_t nchars=0;
+    CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_TYPE_NAME, 0, NULL, &nchars));
+    char* tname = new char[nchars];
+    CHECK_ERR(::clGetKernelArgInfo(k->getRaw(), arg_idx, CL_KERNEL_ARG_TYPE_NAME, nchars, tname, NULL));
+    type_name = std::string(tname);
+    delete [] tname;
+    if (adrqual == CL_KERNEL_ARG_ADDRESS_LOCAL)
+      local_arg = true;
+  } else
+#endif
+  { // behaviour when type is given (mandatory for OpenCL version < 1.2)
+    // read argument 3 as the name of the data type
+    if (args[3]->IsString()) {
+      Local<String> s = args[3]->ToString();
+      String::Utf8Value tname(s);
+      const char* tname_c = *tname;
+      size_t len = tname.length();
+      type_name.resize(len);
+      std::copy(tname_c, tname_c + len, type_name.begin());
+      if (type_name == "local" || type_name == "__local")
+        local_arg = true;
+    } else {
+      return NanThrowError("Typename has to be given as string");
+    }
+  }
 
 
-  // now map the JS parameter `args[2]` to the expected kernel parameter type `typename`
-
-  const char * name = type_name.get();
   cl_int err = 0;
 
-  // first check for pointers (require either local size or cl_mem)
-  if ('*' == name[(strlen(name) - 1)]){
-    // check if type is local or global
-    switch (adrqual) {
-      case CL_KERNEL_ARG_ADDRESS_LOCAL:
-        {
-            // expect a size type
-            if (!args[2]->IsNumber())
-                THROW_ERR(CL_INVALID_ARG_VALUE);
-            // local buffers are intialized with their size (data = NULL)
-            size_t local_size = args[2]->ToInteger()->Value();
-            err = ::clSetKernelArg(k->getRaw(), arg_idx, local_size, NULL);
-        } break;
-      case CL_KERNEL_ARG_ADDRESS_GLOBAL:
-      case CL_KERNEL_ARG_ADDRESS_CONSTANT:
-        {
-          // global and constant memory parameters have to be initialized with
-          // a cl_mem buffer reference
-          NOCL_UNWRAP(mem , NoCLMem, args[2]);
-          err = ::clSetKernelArg(k->getRaw(), arg_idx, sizeof(cl_mem), &mem->getRaw());
-        } break;
-    }
-  } else if (type_converter.hasType(name)) {
+  if (local_arg) {
+    // expect a size type
+    if (!args[2]->IsNumber())
+      THROW_ERR(CL_INVALID_ARG_VALUE);
+    // local buffers are intialized with their size (data = NULL)
+    size_t local_size = args[2]->ToInteger()->Value();
+    err = ::clSetKernelArg(k->getRaw(), arg_idx, local_size, NULL);
+  } else if ('*' == type_name[type_name.length() - 1]){
+    // type must be a buffer (CLMem object)
+    NOCL_UNWRAP(mem , NoCLMem, args[2]);
+    err = ::clSetKernelArg(k->getRaw(), arg_idx, sizeof(cl_mem), &mem->getRaw());
+  } else if (type_converter.hasType(type_name)) {
     // convert primitive types using the conversion
     // function map (indexed by OpenCL type name)
     void* data;
     size_t size;
-    std::tie(size, data, err) = type_converter.convert(name, args[2]);
+    std::tie(size, data, err) = type_converter.convert(type_name, args[2]);
     CHECK_ERR(err);
     err = ::clSetKernelArg(k->getRaw(), arg_idx, size, data);
     free(data);
@@ -299,11 +318,12 @@ NAN_METHOD(SetKernelArg) {
   // TODO: support queue_t and clk_event_t, and others?
 
   // Otherwise it should be a native type
-  else if (strcmp(name, "sampler_t") == 0) {
+  else if (type_name == "sampler_t") {
     NOCL_UNWRAP(sw , NoCLSampler, args[2]);
     err = ::clSetKernelArg(k->getRaw(), arg_idx, sizeof(cl_sampler), &sw->getRaw());
   } else {
-    return NanThrowError("FIXME: Unsupported OpenCL argument type");
+    std::string errstr = std::string("Unsupported OpenCL argument type: ") + type_name;
+    return NanThrowError(errstr.c_str());
   }
 
   CHECK_ERR(err);

--- a/src/memobj.cpp
+++ b/src/memobj.cpp
@@ -43,7 +43,7 @@ void CL_CALLBACK notifyFreeClMemObj (cl_mem mem,void* user_data) {
 //                cl_int *     /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
 NAN_METHOD(CreateBuffer) {
   NanScope();
-  REQ_ARGS(4);
+  REQ_ARGS(3);
 
   // Arg 0
   NOCL_UNWRAP(context, NoCLContext, args[0]);

--- a/src/types.h
+++ b/src/types.h
@@ -90,8 +90,8 @@ public:
     return (this->getRaw() == b.getRaw());
   }
 
-  const T getRaw() const {
-    return (T) this->raw;
+  const T& getRaw() const {
+    return this->raw;
   }
 
   // implicit cast

--- a/test/test.kernel.js
+++ b/test/test.kernel.js
@@ -106,7 +106,10 @@ describe("Kernel", function () {
           var k = cl.createKernel(prg, "square");
           var mem = cl.createBuffer(ctx, 0, 8, null);
 
-          assert(cl.setKernelArg(k, 0, mem) == cl.SUCCESS);
+          if (cl.VERSION_1_2) {
+            assert(cl.setKernelArg(k, 0, mem) == cl.SUCCESS);
+          }
+          assert(cl.setKernelArg(k, 0, mem, "float*") == cl.SUCCESS);
 
           cl.releaseKernel(k);
         });
@@ -118,8 +121,12 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          U.bind(cl.setKernelArg, k, 0, 5)
-            .should.throw(cl.INVALID_MEM_OBJECT.message);
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 0, 5)
+              .should.throw(cl.INVALID_MEM_OBJECT.message);
+          }
+          U.bind(cl.setKernelArg, k, 0, 5, "float*")
+          .should.throw(cl.INVALID_MEM_OBJECT.message);
 
           cl.releaseKernel(k);
         });
@@ -131,8 +138,12 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          U.bind(cl.setKernelArg, k, 0, [5, 10, 15])
-            .should.throw(cl.INVALID_MEM_OBJECT.message);
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 0, [5, 10, 15])
+              .should.throw(cl.INVALID_MEM_OBJECT.message);
+          }
+          U.bind(cl.setKernelArg, k, 0, [5, 10, 15], "float*")
+          .should.throw(cl.INVALID_MEM_OBJECT.message);
 
           cl.releaseKernel(k);
         });
@@ -144,7 +155,10 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          assert(cl.setKernelArg(k, 2, 5) == cl.SUCCESS);
+          if (cl.VERSION_1_2) {
+            assert(cl.setKernelArg(k, 2, 5) == cl.SUCCESS);
+          }
+          assert(cl.setKernelArg(k, 2, 5, "uint") == cl.SUCCESS);
 
           cl.releaseKernel(k);
         });
@@ -156,7 +170,11 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          U.bind(cl.setKernelArg, k, 2, "a")
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 2, "a")
+              .should.throw(cl.INVALID_ARG_VALUE.message);
+          }
+          U.bind(cl.setKernelArg, k, 2, "a", "char")
             .should.throw(cl.INVALID_ARG_VALUE.message);
 
           cl.releaseKernel(k);
@@ -169,7 +187,11 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          U.bind(cl.setKernelArg, k, 2, [5, 10, 15])
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 2, [5, 10, 15])
+              .should.throw(cl.INVALID_ARG_VALUE.message);
+          }
+          U.bind(cl.setKernelArg, k, 2, [5, 10, 15], "int")
             .should.throw(cl.INVALID_ARG_VALUE.message);
 
           cl.releaseKernel(k);
@@ -184,8 +206,12 @@ describe("Kernel", function () {
           var k = cl.createKernel(prg, "square");
           var mem = cl.createBuffer(ctx, 0, 8, null);
 
-          U.bind(cl.setKernelArg, k, 2, mem)
-            .should.throw(cl.INVALID_ARG_VALUE.message);
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 2, mem)
+              .should.throw(cl.INVALID_ARG_VALUE.message);
+          }
+          U.bind(cl.setKernelArg, k, 2, mem, "int")
+          .should.throw(cl.INVALID_ARG_VALUE.message);
 
           cl.releaseKernel(k);
         });
@@ -199,7 +225,11 @@ describe("Kernel", function () {
         U.withProgram(ctx, squareKern, function (prg) {
           var k = cl.createKernel(prg, "square");
 
-          U.bind(cl.setKernelArg, k, 3, 5)
+          if (cl.VERSION_1_2) {
+            U.bind(cl.setKernelArg, k, 3, 5)
+              .should.throw(cl.INVALID_ARG_INDEX.message);
+          }
+          U.bind(cl.setKernelArg, k, 3, 5, "int")
             .should.throw(cl.INVALID_ARG_INDEX.message);
 
           cl.releaseKernel(k);


### PR DESCRIPTION
The last argument to `createBuffer()` is an optional host pointer. The function itself is
already written to check if the `args[3]` is present, but still required 4 arguments on top level.

The third commit also fixes a bug in `setKernelArgs()`.