### PR TITLE
argument 2 is 'local', so size has to be argument 3

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -294,10 +294,10 @@ NAN_METHOD(SetKernelArg) {
 
   if (local_arg) {
     // expect a size type
-    if (!info[2]->IsNumber())
+    if (!info[3]->IsNumber())
       THROW_ERR(CL_INVALID_ARG_VALUE);
     // local buffers are intialized with their size (data = NULL)
-    size_t local_size = info[2]->ToInteger()->Value();
+    size_t local_size = info[3]->ToInteger()->Value();
     err = ::clSetKernelArg(k->getRaw(), arg_idx, local_size, NULL);
   } else if ('*' == type_name[type_name.length() - 1] || type_name == "cl_mem"){
     // type must be a buffer (CLMem object)


### PR DESCRIPTION
The current code can't work:

// read argument 2 as the name of the data type                                                                                                                               
    if (info[2]->IsString()) {
     ...
      if (type_name == "local" || type_name == "__local")
        local_arg = true;
    } else {
      return Nan::ThrowError("Typename has to be given as string");
    }

and then

  if (local_arg) {
    // expect a size type                                                                                                                                                         
    if (!info[2]->IsNumber())
      THROW_ERR(CL_INVALID_ARG_VALUE);

I think you mean [3] here. Wdyt?