### PR TITLE
always increment the ref count when storing a ref counted handle

### DIFF
--- a/src/commandqueue.cpp
+++ b/src/commandqueue.cpp
@@ -141,12 +141,14 @@ NAN_METHOD(GetCommandQueueInfo) {
     case CL_QUEUE_CONTEXT: {
       cl_context val;
       CHECK_ERR(::clGetCommandQueueInfo(q->getRaw(),param_name,sizeof(cl_context), &val, nullptr))
+      CHECK_ERR(::clRetainContext(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLContext, val));
       return;
     }
     case CL_QUEUE_DEVICE: {
       cl_device_id val;
       CHECK_ERR(::clGetCommandQueueInfo(q->getRaw(),param_name,sizeof(cl_device_id), &val, nullptr))
+      CHECK_ERR(::clRetainDevice(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLDeviceId, val));
       return;
     }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -173,6 +173,7 @@ NAN_METHOD(GetContextInfo) {
 
     Local<Array> arr = Nan::New<Array>((int)n);
     for(uint32_t i=0;i<n;i++) {
+      CHECK_ERR(::clRetainDevice(devices[i]))
       arr->Set(i, NOCL_WRAP(NoCLDeviceId, devices[i]));
     }
     info.GetReturnValue().Set(arr);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -42,6 +42,7 @@ NAN_METHOD(GetEventInfo) {
     {
       cl_command_queue val;
       CHECK_ERR(::clGetEventInfo(ev->getRaw(),param_name,sizeof(cl_command_queue), &val, NULL))
+      CHECK_ERR(::clRetainCommandQueue(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLCommandQueue, val));
       return;
     }
@@ -49,6 +50,7 @@ NAN_METHOD(GetEventInfo) {
     {
       cl_context val;
       CHECK_ERR(::clGetEventInfo(ev->getRaw(),param_name,sizeof(cl_context), &val, NULL))
+      CHECK_ERR(::clRetainContext(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLContext, val));
       return;
     }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -55,6 +55,7 @@ NAN_METHOD(CreateKernelsInProgram) {
   Local<Array> karr = Nan::New<Array>();
 
   for(cl_uint i = 0; i < numkernels;i++) {
+    CHECK_ERR(::clRetainKernel(kernels[i]))
     karr->Set(i,NOCL_WRAP(NoCLKernel, kernels[i]));
   }
 
@@ -368,12 +369,14 @@ NAN_METHOD(GetKernelInfo) {
     case CL_KERNEL_CONTEXT: {
       cl_context ctx=0;
       CHECK_ERR(::clGetKernelInfo(k->getRaw(),param_name,sizeof(cl_context),&ctx, NULL));
+      CHECK_ERR(::clRetainContext(ctx))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLContext, ctx));
       return;
     }
     case CL_KERNEL_PROGRAM: {
       cl_program p=0;
       CHECK_ERR(::clGetKernelInfo(k->getRaw(),param_name,sizeof(cl_program),&p, NULL));
+      CHECK_ERR(::clRetainProgram(p))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLProgram, p));
       return;
     }

--- a/src/memobj.cpp
+++ b/src/memobj.cpp
@@ -326,12 +326,14 @@ NAN_METHOD(GetMemObjectInfo) {
     case CL_MEM_CONTEXT: {
       cl_context val;
       CHECK_ERR(::clGetMemObjectInfo(mem->getRaw(),param_name,sizeof(cl_context), &val, NULL))
+      CHECK_ERR(::clRetainContext(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLContext, val));
       return;
     }
     case CL_MEM_ASSOCIATED_MEMOBJECT: {
       cl_mem val;
       CHECK_ERR(::clGetMemObjectInfo(mem->getRaw(),param_name,sizeof(cl_mem), &val, NULL))
+      CHECK_ERR(::clRetainMemObject(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLMem, val));
       return;
     }
@@ -384,6 +386,7 @@ NAN_METHOD(GetImageInfo) {
     case CL_IMAGE_BUFFER: {
       cl_mem val;
       CHECK_ERR(::clGetImageInfo(mem->getRaw(),param_name,sizeof(cl_mem), &val, NULL))
+      CHECK_ERR(::clRetainMemObject(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLMem, val));
       return;
     }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -476,6 +476,7 @@ NAN_METHOD(GetProgramInfo) {
     {
       cl_context val;
       CHECK_ERR(::clGetProgramInfo(prog->getRaw(),param_name,sizeof(cl_context), &val, NULL))
+      CHECK_ERR(::clRetainContext(val))
       info.GetReturnValue().Set(NOCL_WRAP(NoCLContext, val));
       return;
     }
@@ -490,6 +491,7 @@ NAN_METHOD(GetProgramInfo) {
 
       Local<Array> arr = Nan::New<Array>((int)n);
       for(uint32_t i=0;i<n;i++) {
+        CHECK_ERR(::clRetainDevice(devices[i]))
         arr->Set(i, NOCL_WRAP(NoCLDeviceId, devices[i]));
       }
 


### PR DESCRIPTION
This fixes issue #40. Always manually retain any reference counted CL handle when CL doesn't already increment the counter (this is mostly the clGetXXXInfo APIs). This avoids a crash when a GC triggers, but is also generally needed to avoid dangling pointers in case the original object goes out of scope and is GCed.