### PR TITLE
Fix of vector argument

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -59,7 +59,7 @@ NAN_METHOD(CreateKernelsInProgram) {
     karr->Set(i,NOCL_WRAP(NoCLKernel, kernels[i]));
   }
 
-  delete kernels;
+  delete[] kernels;
 
   info.GetReturnValue().Set(karr);
 }
@@ -213,7 +213,7 @@ public:
   std::tuple<size_t, void*, cl_int> convert(const std::string& name, const Local<Value>& val) {
       assert(this->hasType(name));
       // call conversion function and return size of argument and pointer
-      return std::move(m_converters[name](val));
+      return m_converters[name](val);
   }
 
 };

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -166,7 +166,7 @@ public:
         }                                                                       \
         return std::tuple<size_t,void*,cl_int>(ptr_size, ptr_data, 0);          \
       };                                                                        \
-      m_converters["NAME ## I"] = f;                                            \
+      m_converters[NAME #I ] = f;                                            \
       }
 
     #define CONVERT_VECTS(NAME, TYPE, PRED, COND) \
@@ -174,14 +174,14 @@ public:
       CONVERT_VECT(NAME, TYPE, 3, PRED, COND);\
       CONVERT_VECT(NAME, TYPE, 4, PRED, COND);\
       CONVERT_VECT(NAME, TYPE, 8, PRED, COND);\
-      CONVERT_VECT(MAME, TYPE, 16, PRED, COND);
+      CONVERT_VECT(NAME, TYPE, 16, PRED, COND);
 
     CONVERT_VECTS("char", cl_char, IsInt32, ToInt32()->Value);
     CONVERT_VECTS("uchar", cl_uchar, IsInt32, ToUint32()->Value);
     CONVERT_VECTS("short", cl_short, IsInt32, ToInt32()->Value);
     CONVERT_VECTS("ushort", cl_ushort, IsInt32, ToUint32()->Value);
     CONVERT_VECTS("int", cl_int, IsInt32, ToInt32()->Value);
-    CONVERT_VECTS("uint", cl_uint, IsInt32, ToUint32()->Value);
+    CONVERT_VECTS("uint", cl_uint, IsUint32, ToUint32()->Value);
     CONVERT_VECTS("long", cl_long, IsNumber, ToInteger()->Value);
     CONVERT_VECTS("ulong", cl_ulong, IsNumber, ToInteger()->Value);
     CONVERT_VECTS("float", cl_float, IsNumber, NumberValue);


### PR DESCRIPTION
I found that it is impossible to use argument of vector type (int4, float8 etc.) by minor bugs. Here is the patch.