### PR TITLE
fix two compiler warnings

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -59,7 +59,7 @@ NAN_METHOD(CreateKernelsInProgram) {
     karr->Set(i,NOCL_WRAP(NoCLKernel, kernels[i]));
   }
 
-  delete kernels;
+  delete[] kernels;
 
   info.GetReturnValue().Set(karr);
 }
@@ -213,7 +213,7 @@ public:
   std::tuple<size_t, void*, cl_int> convert(const std::string& name, const Local<Value>& val) {
       assert(this->hasType(name));
       // call conversion function and return size of argument and pointer
-      return std::move(m_converters[name](val));
+      return m_converters[name](val);
   }
 
 };


### PR DESCRIPTION
This fixes two compiler warnings. The first is a new[]/delete mismatch.

The other one -- move() -- I don't fully understand:

../src/kernel.cpp:215:14: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
      return std::move(m_converters[name](val));
             ^
../src/kernel.cpp:215:14: note: remove std::move call here
      return std::move(m_converters[name](val));
             ^~~~~~~~~~                       ~

But should work without std::move() here. Please double check.