### PR TITLE
retain device references returned by GetDeviceIDs

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -28,6 +28,8 @@ NAN_METHOD(GetDeviceIDs) {
 
   Local<Array> deviceArray = Nan::New<Array>(n);
   for (uint32_t i=0; i<n; i++) {
+    // This is a noop for root-level devices but properly retains sub-devices.
+    CHECK_ERR(::clRetainDevice(devices[i]));
     deviceArray->Set(i, NOCL_WRAP(NoCLDeviceId, devices[i]));
   }
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -55,7 +55,9 @@ NAN_METHOD(CreateKernelsInProgram) {
   Local<Array> karr = Nan::New<Array>();
 
   for(cl_uint i = 0; i < numkernels;i++) {
-    CHECK_ERR(::clRetainKernel(kernels[i]))
+    // This should not be needed. clCreateKernelsInProgram implicitly does clRetainKernel
+    // on each kernel
+    // CHECK_ERR(::clRetainKernel(kernels[i]))
     karr->Set(i,NOCL_WRAP(NoCLKernel, kernels[i]));
   }
 


### PR DESCRIPTION
I found another missing retain and we should update npm. I accidentally used the npm version and chased my own tail for a while since npm's version doesn't contain the other set of clRetain* fixes.