### PR TITLE
Move some things from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,13 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "chai": ">=2.0.0",
-    "get-pixels": ">=3.1.1",
-    "memwatch-next": "^0.2.10",
-    "nan": "^2.1.0",
-    "pngjs2": "*"
+    "nan": "^2.1.0"
   },
   "devDependencies": {
     "chalk": ">=0.5.1",
+    "chai": ">=2.0.0",
+    "get-pixels": ">=3.1.1",
+    "memwatch-next": "^0.2.10",
     "mocha": "*"
   },
   "gypfile": true,


### PR DESCRIPTION
As far as I can tell, these dependencies are only needed for development.

When new releases of v8 include breaking changes that don't affect node-opencl, but do affect dependencies like `memwatch-next` or `pngjs2`, including those dependencies in the production list breaks the builds of node-opencl consumers until they update. This PR should make us more resilient against these types of changes.